### PR TITLE
ESLint line endings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,9 @@
         ],
         "no-undef": [
             "off"
+        ],
+        "linebreak-style": [
+            "off"
         ]
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,7 @@
             4
         ],
         "linebreak-style": [
-            "error",
+            "off",
             "unix"
         ],
         "quotes": [
@@ -36,9 +36,6 @@
             }
         ],
         "no-undef": [
-            "off"
-        ],
-        "linebreak-style": [
             "off"
         ]
     }


### PR DESCRIPTION
Git for Windows checks out CRLF line endings so ESLint complains. We don't care about this so this PR disables that rule.