### PR TITLE
Fix Prettier to not Conflict with ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,10 @@
         ],
         "no-undef": [
             "off"
+        ],
+        "comma-dangle": [
+            "error",
+            "never"
         ]
     }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+    "indent": 4,
+    "quotes": "double",
+    "semi": "always"
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
-    "indent": 4,
-    "quotes": "double",
-    "semi": "always"
+    "tabWidth": 4,
+    "singleQuote": false,
+    "semi": true,
+    "trailingComma": "none"
 }


### PR DESCRIPTION
It just took a small configuration file. Shouldn't obliterate proper formatting on save anymore.

Closes #20.